### PR TITLE
put libraries last in order to fix link error on ubuntu 14.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 endif
 
 cp437: cp437.c
-	$(CC) $(CFLAGS) $(LIBS) -o $@ $<
+	$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 clean:
 	rm -f cp437


### PR DESCRIPTION
Otherwise I end up with the following error:
,----
| gcc -Wall -lutil -o cp437 cp437.c
| /tmp/ccKg5S53.o: In function `main':
| cp437.c:(.text+0x40b): undefined reference to`forkpty'
| collect2: error: ld returned 1 exit status
| make: **\* [cp437] Error 1
`----
