### PR TITLE
Added check for Termux to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ ifeq ($(SYSTEM),$(filter $(SYSTEM),FreeBSD OpenBSD))
 else
 ifeq ($(SYSTEM),Darwin)
 	LIBS+= -liconv
+else
+ifeq ($(shell uname -o),Android)
+	LIBS+= -L/data/data/com.termux/files/usr/lib -liconv
+endif
 endif
 endif
 

--- a/README
+++ b/README
@@ -15,9 +15,9 @@ Building
 
 Just running "make" (or "gmake" on BSD systems) should build the cp437 binary.  
 You'll need iconv, which is provided by glibc on Linux but is provided by the 
-libiconv port on FreeBSD.  As yet I've not tested it on any operating systems
-other than those two, although it is reputed to work on OS X and OpenBSD too - 
-feedback is welcome.
+libiconv port on FreeBSD and on Termux.  As yet I've not tested it on any 
+operating systems other than the above, although it is reputed to work on OS X 
+and OpenBSD too - feedback is welcome.
 
 You can move the binary wherever you like - I suggest $HOME/bin.
 


### PR DESCRIPTION
I have added a simple check in the Makefile which facilitates building on Termux (on Android).